### PR TITLE
feat: trigger extra hook simulation on order review

### DIFF
--- a/apps/cowswap-frontend/src/common/containers/OrderHooksDetails/styled.tsx
+++ b/apps/cowswap-frontend/src/common/containers/OrderHooksDetails/styled.tsx
@@ -33,6 +33,17 @@ export const Label = styled.span`
   gap: 4px;
 `
 
+export const ErrorLabel = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(${UI.COLOR_DANGER_TEXT});
+  background-color: var(${UI.COLOR_DANGER_BG});
+  border-radius: 8px;
+  margin-left: 4px;
+  padding: 2px 6px;
+`
+
 export const Content = styled.div`
   display: flex;
   width: max-content;
@@ -163,4 +174,22 @@ export const CircleCount = styled.span`
   font-size: 12px;
   font-weight: var(${UI.FONT_WEIGHT_BOLD});
   margin: 0;
+`
+
+export const Spinner = styled.div`
+  border: 5px solid transparent;
+  border-top-color: ${`var(${UI.COLOR_PRIMARY_LIGHTER})`};
+  border-radius: 50%;
+  width: 12px;
+  height: 12px;
+  animation: spin 1.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) infinite;
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
 `

--- a/apps/cowswap-frontend/src/modules/hooksStore/hooks/useHooksStateWithSimulatedGas.ts
+++ b/apps/cowswap-frontend/src/modules/hooksStore/hooks/useHooksStateWithSimulatedGas.ts
@@ -14,9 +14,9 @@ export function useHooksStateWithSimulatedGas(): HooksStoreState {
 
   const combineHookWithSimulatedGas = useCallback(
     (hook: CowHookDetails): CowHookDetails => {
-      const simulatedGasUsed = tenderlyData?.[hook.uuid]?.gasUsed
-      if (!simulatedGasUsed || simulatedGasUsed === '0') return hook
-      const hookData = { ...hook.hook, gasLimit: simulatedGasUsed }
+      const hookTenderlyData = tenderlyData?.[hook.uuid]
+      if (!hookTenderlyData?.gasUsed || hookTenderlyData.gasUsed === '0' || !hookTenderlyData.status) return hook
+      const hookData = { ...hook.hook, gasLimit: hookTenderlyData.gasUsed }
       return { ...hook, hook: hookData }
     },
     [tenderlyData],

--- a/apps/cowswap-frontend/src/modules/hooksStore/pure/AppliedHookItem/index.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/pure/AppliedHookItem/index.tsx
@@ -7,7 +7,7 @@ import ICON_X from '@cowprotocol/assets/cow-swap/x.svg'
 import { CowHookDetails } from '@cowprotocol/hook-dapp-lib'
 import { InfoTooltip } from '@cowprotocol/ui'
 
-import { Edit2, Trash2, ExternalLink as ExternalLinkIcon } from 'react-feather'
+import { Edit2, Trash2, ExternalLink as ExternalLinkIcon, RefreshCw } from 'react-feather'
 import SVG from 'react-inlinesvg'
 
 import { useTenderlyBundleSimulation } from 'modules/tenderly/hooks/useTenderlyBundleSimulation'
@@ -31,7 +31,7 @@ interface HookItemProp {
 const isBundleSimulationReady = true
 
 export function AppliedHookItem({ account, hookDetails, dapp, isPreHook, editHook, removeHook, index }: HookItemProp) {
-  const { isValidating, data } = useTenderlyBundleSimulation()
+  const { isValidating, data, mutate } = useTenderlyBundleSimulation()
 
   const simulationData = useMemo(() => {
     if (!data) return
@@ -56,6 +56,9 @@ export function AppliedHookItem({ account, hookDetails, dapp, isPreHook, editHoo
           {isValidating && <styledEl.Spinner />}
         </styledEl.HookItemInfo>
         <styledEl.HookItemActions>
+          <styledEl.ActionBtn onClick={() => mutate()} disabled={isValidating}>
+            <RefreshCw size={14} />
+          </styledEl.ActionBtn>
           <styledEl.ActionBtn onClick={() => editHook(hookDetails.uuid)}>
             <Edit2 size={14} />
           </styledEl.ActionBtn>

--- a/apps/cowswap-frontend/src/modules/tenderly/utils/bundleSimulation.ts
+++ b/apps/cowswap-frontend/src/modules/tenderly/utils/bundleSimulation.ts
@@ -1,17 +1,20 @@
-import { Erc20 } from '@cowprotocol/abis'
+import { Erc20Abi } from '@cowprotocol/abis'
 import { BFF_BASE_URL } from '@cowprotocol/common-const'
 import { COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { CowHookDetails } from '@cowprotocol/hook-dapp-lib'
+
+import { Interface } from 'ethers/lib/utils'
 
 import { CowHook } from 'modules/hooksStore/types/hooks'
 
 import { SimulationData, SimulationInput } from '../types'
 
+const erc20Interface = new Interface(Erc20Abi)
 export interface GetTransferTenderlySimulationInput {
   currencyAmount: string
   from: string
   receiver: string
-  token: Erc20
+  token: string
 }
 
 export type TokenBuyTransferInfo = {
@@ -21,8 +24,8 @@ export type TokenBuyTransferInfo = {
 export interface PostBundleSimulationParams {
   account: string
   chainId: SupportedChainId
-  tokenSell: Erc20
-  tokenBuy: Erc20
+  tokenSell: string
+  tokenBuy: string
   preHooks: CowHookDetails[]
   postHooks: CowHookDetails[]
   sellAmount: string
@@ -71,11 +74,11 @@ export function getTransferTenderlySimulationInput({
   receiver,
   token,
 }: GetTransferTenderlySimulationInput): SimulationInput {
-  const callData = token.interface.encodeFunctionData('transfer', [receiver, currencyAmount])
+  const callData = erc20Interface.encodeFunctionData('transfer', [receiver, currencyAmount])
 
   return {
     input: callData,
-    to: token.address,
+    to: token,
     from,
   }
 }


### PR DESCRIPTION
# Summary

Since simulations are only triggered on hook changes, sometimes the user can't see that the hook is falling. This PR adds one extra simulation on the order review.


https://github.com/user-attachments/assets/c5b8a418-1132-491e-821b-a5ccd6602ced

# To Test

You can follow the same process that I did on the video.

